### PR TITLE
Align driver name when adding new

### DIFF
--- a/apps/Rheem_EcoNet_Integration.groovy
+++ b/apps/Rheem_EcoNet_Integration.groovy
@@ -181,7 +181,7 @@ def createChildDevices() {
         def device = getChildDevice("rheem:" + waterHeater)
         if (!device)
         {
-            device = addChildDevice("dcm.rheem", "Rheem Econet Water Heater", "rheem:" + waterHeater, 1234, ["name": state.deviceList[waterHeater], isComponent: false])
+            device = addChildDevice("klinquist.rheem", "Rheem Econet Water Heater", "rheem:" + waterHeater, 1234, ["name": state.deviceList[waterHeater], isComponent: false])
         }
         if (state.devicesModes == null)
             state.deviceModes = [:]


### PR DESCRIPTION
Without this an error is thrown when adding a new device through the app.

`com.hubitat.app.exception.UnknownDeviceTypeException: Device type 'Rheem Econet Water Heater' in namespace 'dcm.rheem' not found on line 184
`

**warning**: I don't have any idea what I'm doing (never worked with anything in this stack before), just looks like a fairly straightfoward fix so I thought I'd send it your way